### PR TITLE
New option added to keep raw field for all String field types (upto m…

### DIFF
--- a/src/test/java/org/datacleaner/extension/elasticsearch/ElasticSearchIndexAnalyzerIntegrationTest.java
+++ b/src/test/java/org/datacleaner/extension/elasticsearch/ElasticSearchIndexAnalyzerIntegrationTest.java
@@ -102,15 +102,21 @@ public class ElasticSearchIndexAnalyzerIntegrationTest extends TestCase {
         }
 
         WriteDataResult result = (WriteDataResult) resultFuture.getResults().get(0);
-        assertEquals(8, result.getWrittenRowCount());
+        assertEquals(9, result.getWrittenRowCount());
 
-        assertEquals(8, _server.getDocumentCount());
+        assertEquals(9, _server.getDocumentCount());
 
         try (Client client = _server.getClient()) {
             SearchResponse searchResponse = new SearchRequestBuilder(client)
                     .setIndices(ElasticSearchTestServer.INDEX_NAME).setTypes(ElasticSearchTestServer.DOCUMENT_TYPE)
                     .setQuery(QueryBuilders.queryString("Allersgade")).execute().actionGet();
             assertEquals(2l, searchResponse.getHits().getTotalHits());
+
+            searchResponse = new SearchRequestBuilder(client)
+                    .setIndices(ElasticSearchTestServer.INDEX_NAME).setTypes(ElasticSearchTestServer.DOCUMENT_TYPE)
+                    .setQuery(QueryBuilders.termQuery("street.raw", "Burgmeester Daleslaan")).execute().actionGet();
+            assertEquals(1l, searchResponse.getHits().getTotalHits());
+
         } catch (Exception e) {
             e.printStackTrace();
             throw e;

--- a/src/test/resources/AddressAccess.csv
+++ b/src/test/resources/AddressAccess.csv
@@ -7,4 +7,4 @@ AddressAccessIdentifier;StreetName;StreetBuildingIdentifier;PostCodeIdentifier;D
 1006;Nørrebrogade;95;2200;København N
 1007;Allersgade;2;2200;København N
 1008;Allersgade;4;2200;København N
-1009;Burgmeester Daleslaan;56;1082NV;Nijmegen
+1009;Burgmeester Daleslaan;27;6532 CL;Nijmegen

--- a/src/test/resources/AddressAccess.csv
+++ b/src/test/resources/AddressAccess.csv
@@ -7,3 +7,4 @@ AddressAccessIdentifier;StreetName;StreetBuildingIdentifier;PostCodeIdentifier;D
 1006;Nørrebrogade;95;2200;København N
 1007;Allersgade;2;2200;København N
 1008;Allersgade;4;2200;København N
+1009;Burgmeester Daleslaan;56;1082NV;Nijmegen


### PR DESCRIPTION
…axlength 256). The option is by default ON, so all new indexes will also always have RAW fields for the string field type in the ES index. This helps in solving the aggregation count issue. Counting on analyzed fields shows counts for 'United Kingdom' shows results 2 types with United - 10 and Kingdom - 10.